### PR TITLE
Portal direction bugfix

### DIFF
--- a/src/main/java/com/gmail/trentech/pjp/commands/portal/CMDCreate.java
+++ b/src/main/java/com/gmail/trentech/pjp/commands/portal/CMDCreate.java
@@ -160,7 +160,7 @@ public class CMDCreate implements CommandExecutor {
 				coordinate = Optional.of(new Coordinate(world.get(), false, false));
 			}
 
-			if (args.hasAny("rotation")) {
+			if (args.hasAny("direction")) {
 				rotation.set(args.<Rotation>getOne("direction").get());
 			}
 


### PR DESCRIPTION
Code checks if argument "rotation" exists, however it skips "direction" argument so portal direction will be always default - east.