### PR TITLE
Fix command executors and help text

### DIFF
--- a/src/main/java/com/gmail/trentech/pjp/commands/portal/CMDPermission.java
+++ b/src/main/java/com/gmail/trentech/pjp/commands/portal/CMDPermission.java
@@ -18,7 +18,7 @@ public class CMDPermission implements CommandExecutor {
 
 	@Override
 	public CommandResult execute(CommandSource src, CommandContext args) throws CommandException {
-		Help help = Help.get("portal price").get();
+		Help help = Help.get("portal permission").get();
 		
 		if (args.hasAny("help")) {		
 			help.execute(src);

--- a/src/main/java/com/gmail/trentech/pjp/init/Commands.java
+++ b/src/main/java/com/gmail/trentech/pjp/init/Commands.java
@@ -183,7 +183,7 @@ public class Commands {
 		    .arguments(
 		    		GenericArguments.optional(new PortalElement(Text.of("name"), PortalType.PORTAL)), 
 		    		GenericArguments.optional(GenericArguments.string(Text.of("permission"))))
-		    .executor(new com.gmail.trentech.pjp.commands.portal.CMDPrice())
+		    .executor(new com.gmail.trentech.pjp.commands.portal.CMDPermission())
 		    .build();
 	
 	private CommandSpec cmdPortalCommand = CommandSpec.builder()
@@ -192,7 +192,7 @@ public class Commands {
 		    .arguments(
 		    		GenericArguments.optional(new PortalElement(Text.of("name"), PortalType.PORTAL)), 
 		    		GenericArguments.optional(GenericArguments.remainingJoinedStrings(Text.of("command"))))
-		    .executor(new com.gmail.trentech.pjp.commands.portal.CMDPrice())
+		    .executor(new com.gmail.trentech.pjp.commands.portal.CMDCommand())
 		    .build();
 	
 	private CommandSpec cmdPortalList = CommandSpec.builder()


### PR DESCRIPTION
- Fix command executors and help for command/permission sub-commands (fixes #128, #132)
- Fixes incorrect help text for `/portal permission`